### PR TITLE
Added fallback for undefined response headers coming from Cloudscraper

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -150,8 +150,8 @@ var NodeBittrexApi = function() {
         console.error(error);
       } else {
         opts.headers = {
-          cookie: response.request.headers["cookie"],
-          user_agent: response.request.headers["User-Agent"]
+          cookie: (response.request.headers["cookie"] || ''),
+          user_agent: (response.request.headers["User-Agent"] || '')
         };
         wsclient = new signalR.client(
           opts.websockets_baseurl,


### PR DESCRIPTION
Issue describing the bug here: https://github.com/dparlevliet/node.bittrex.api/issues/11

Basically, SignalR doesn't seem to like undefined headers being passed to it, so if the Cloudscraper response doesn't have a cookie header it will throw, even if it doesn't need it.