### PR TITLE
Add ability to create api instances with own options

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -37,6 +37,9 @@ var NodeBittrexApi = function() {
     verbose: false,
     cleartext: false,
     inverse_callback_arguments: false,
+    websockets: {
+      autoReconnect: true,
+    }
   };
 
   var lastNonces = [];
@@ -196,7 +199,17 @@ var NodeBittrexApi = function() {
             if (opts.websockets && typeof(opts.websockets.onDisconnect) === 'function') {
               opts.websockets.onDisconnect();
             }
-            wsclient.start(); // ensure we try reconnect
+
+            if (
+              opts.websockets &&
+              (
+                opts.websockets.autoReconnect === true ||
+                typeof(opts.websockets.autoReconnect) === 'undefined'
+              )
+            ) {
+              ((opts.verbose) ? console.log('Websocket auto reconnecting.') : '');
+              wsclient.start(); // ensure we try reconnect
+            }
           },
           onerror: function(error) {
             ((opts.verbose) ? console.log('Websocket onerror: ', error) : '');

--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -7,7 +7,7 @@
  * Released under the MIT License
  * ============================================================ */
 
-var NodeBittrexApi = function() {
+var NodeBittrexApi = function(options) {
   'use strict';
 
   var request = require('request'),
@@ -68,6 +68,10 @@ var NodeBittrexApi = function() {
       opts[o[i]] = options[o[i]];
     }
   };
+
+  if (options) {
+    extractOptions(options);
+  }
 
   var apiCredentials = function(uri) {
     var options = {
@@ -374,6 +378,8 @@ var NodeBittrexApi = function() {
       credentialApiCall(opts.baseUrl + '/account/withdraw', callback, options);
     }
   };
-}();
+};
 
-module.exports = NodeBittrexApi;
+module.exports = NodeBittrexApi();
+
+module.exports.createInstance = NodeBittrexApi;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "node.bittrex.api",
-  "version": "0.6.4",
+  "name": "node-bittrex-api",
+  "version": "0.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -82,6 +82,14 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cloudscraper": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cloudscraper/-/cloudscraper-1.4.1.tgz",
+      "integrity": "sha1-8rRDHzFyhtgZsTVyZso0Y7ES68o=",
+      "requires": {
+        "request": "2.81.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -157,11 +165,6 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -176,20 +179,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
-      }
     },
     "extend": {
       "version": "3.0.1",
@@ -215,11 +204,6 @@
         "combined-stream": "1.0.5",
         "mime-types": "2.1.16"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -380,20 +364,6 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -479,11 +449,6 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -576,14 +541,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
@@ -649,14 +606,6 @@
         "hoek": "2.16.3"
       }
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -679,14 +628,6 @@
         }
       }
     },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "requires": {
-        "duplexer": "0.1.1"
-      }
-    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -700,11 +641,6 @@
       "requires": {
         "has-flag": "1.0.0"
       }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tough-cookie": {
       "version": "2.3.2",

--- a/tests/private.js
+++ b/tests/private.js
@@ -1,9 +1,7 @@
 var assert = require('assert');
-var bittrex = require('../node.bittrex.api.js');
 var fs = require('fs');
 var config = JSON.parse(fs.readFileSync(__dirname+'/config.json'));
-
-bittrex.options({
+var bittrex = require('../node.bittrex.api.js')({
   'apikey' : config.api.key,
   'apisecret' : config.api.secret,
 });

--- a/tests/websocket.js
+++ b/tests/websocket.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var bittrex = require('../node.bittrex.api.js')();
+var bittrex = require('../node.bittrex.api.js');
 
 describe('Bittrex websocket API', function() {
 

--- a/tests/websocket.js
+++ b/tests/websocket.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var bittrex = require('../node.bittrex.api.js');
+var bittrex = require('../node.bittrex.api.js')();
 
 describe('Bittrex websocket API', function() {
 


### PR DESCRIPTION
I implemented ability to create api instances with own options. Also I saved original library behavior to save backward compatibility.

Example:

```javascript
import { createInstance } from 'node-bittrex-api';

const bittrex = createInstance({
  apikey: 'key',
  apisecret: 'secret',
});

bittrex.getbalances( function( data, err ) {
  console.log( data );
});
```

  