### PR TITLE
Added missed 'force' parameter to websocket methods to allow reconnection

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -305,22 +305,22 @@ var NodeBittrexApi = function() {
       extractOptions(options);
     },
     websockets: {
-      client: function(callback) {
-        return connectws(callback);
+      client: function(callback, force) {
+        return connectws(callback, force);
       },
-      listen: function(callback) {
+      listen: function(callback, force) {
         connectws(function() {
           websocketGlobalTickers = true;
           websocketGlobalTickerCallback = callback;
           setMessageReceivedWs();
-        });
+        }, force);
       },
-      subscribe: function(markets, callback) {
+      subscribe: function(markets, callback, force) {
         connectws(function() {
           websocketMarkets = markets;
           websocketMarketsCallback = callback;
           setMessageReceivedWs();
-        });
+        }, force);
       }
     },
     sendCustomRequest: function(request_string, callback, credentials) {


### PR DESCRIPTION
Hi!

Sometimes websocket connection may stuck, and there wasn't any ability to force reconnection. I have added missed 'force' parameter which will help to reconnect again.