### PR TITLE
Fix to clear watchdog on disconnect when autoreconnect is disabled

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -260,6 +260,12 @@ var NodeBittrexApi = function() {
           ) {
             ((opts.verbose) ? console.log('Websocket auto reconnecting.') : '');
             wsclient.start(); // ensure we try reconnect
+          } else {
+            // otherwise, clear the watchdog interval if necessary
+            if (websocketWatchDog) {
+              clearInterval(websocketWatchDog);
+              websocketWatchDog = null;
+            }
           }
         },
         onerror: function(error) {


### PR DESCRIPTION
The new `websocketWatchDog` interval is meant to help force auto-reconnects for stalled connections, but it's currently impossible to remove when trying to disconnect the websocket connection. This PR clears the interval when the websocket connection disconnects when auto-reconnect is disabled (so the connection really is disconnected). It's the only remaining open scheduled item in the event queue, which prevents node from exiting (and thus is kind of a memory leak).

A more complete fix might prevent the interval from being created in the first place if auto reconnect is disabled (since it won't do anything anyway), but I don't have time to test it properly and this works and makes sense.