### PR TITLE
Add support for client supplied cloudscaper headers.

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -324,7 +324,7 @@ var NodeBittrexApi = function(options) {
         callback(wsclient);
       }
       
-    });
+    }, opts.cloudscraper_headers || {});
 
     return wsclient;
   };


### PR DESCRIPTION
Cloudflare doesn't like not getting browser-like headers.